### PR TITLE
docs: Updated docs for TLS options for syslog TCP server

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -121,6 +121,10 @@ OpenObserve is configured through the use of below environment variables.
 | ZO_ALERT_SCHEDULE_INTERVAL           |                            | No           |  |
 | ZO_TCP_PORT                          | 5514                       | No           | TCP port for syslog  |
 | ZO_UDP_PORT                          | 5514                       | No           | UDP port for syslog  |
+| ZO_TCP_TLS_ENABLED                   | false                      | No           | Enable TLS for TCP syslog server. |
+| ZO_TCP_TLS_CERT_PATH                 |                            | No           | Path to the TLS certificate file to be used on the server. |
+| ZO_TCP_TLS_KEY_PATH                  |                            | No           | Path to the TLS key file to be used on the server. |
+| ZO_TCP_TLS_CA_CERT_PATH              |                            | No           | Path to the TLS CA certificate file to be used on the server. |
 | ZO_APP_NAME                          |                            | No           |  |
 | ZO_DEFAULT_SCRAPE_INTERVAL           |                            | No           |  |
 | ZO_CIRCUIT_BREAKER_ENABLE            |                            | No           |  |

--- a/docs/ingestion/logs/syslog.md
+++ b/docs/ingestion/logs/syslog.md
@@ -27,9 +27,11 @@ You can change the default port number using the following environment variables
 
 You can also configure the TLS settings for syslog TCP server using the following environment variables:
 * `ZO_TCP_TLS_ENABLED` - Enable TLS for TCP syslog server. If enabled, `ZO_TCP_PORT` will be used for the TLS connection over TCP. Default: `false`
+
+If `ZO_TCP_TLS_ENABLED` is set to `true`, then make sure to set all the below variables in production:
 * `ZO_TCP_TLS_CERT_PATH` - Path to the TLS certificate file to be used on the server.
 * `ZO_TCP_TLS_KEY_PATH` - Path to the TLS key file to be used on the server.
-* `ZO_TCP_TLS_CA_CERT_PATH` - Path to the TLS CA certificate file to be used on the server.
+* `ZO_TCP_TLS_CA_CERT_PATH` - Path to the TLS CA certificate file to be used on the server. It is recommended to set this variable if the above 2 variables are set, otherwise, the configured certificate will be treated as a self-signed certificate. This is useful for development and internal testing, but not recommended for production setups as it could still be vulnerable to man-in-the-middle attacks.
 
 
 ## Testing

--- a/docs/ingestion/logs/syslog.md
+++ b/docs/ingestion/logs/syslog.md
@@ -25,6 +25,12 @@ You can change the default port number using the following environment variables
 * `ZO_TCP_PORT` - TCP port number to listen on. Default: `5514`
 * `ZO_UDP_PORT` - UDP port number to listen on. Default: `5514`
 
+You can also configure the TLS settings for syslog TCP server using the following environment variables:
+* `ZO_TCP_TLS_ENABLED` - Enable TLS for TCP syslog server. If enabled, `ZO_TCP_PORT` will be used for the TLS connection over TCP. Default: `false`
+* `ZO_TCP_TLS_CERT_PATH` - Path to the TLS certificate file to be used on the server.
+* `ZO_TCP_TLS_KEY_PATH` - Path to the TLS key file to be used on the server.
+* `ZO_TCP_TLS_CA_CERT_PATH` - Path to the TLS CA certificate file to be used on the server.
+
 
 ## Testing
 


### PR DESCRIPTION
This PR updates the documentation for syslog and for environment variables to reflect the new configuration environment variables for enabling TLS support in syslog TCP server.